### PR TITLE
Support for "away" preset mode and "idle" action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.idea
+
 # C extensions
 *.so
 

--- a/custom_components/climate_group/climate.py
+++ b/custom_components/climate_group/climate.py
@@ -238,13 +238,13 @@ class ClimateGroup(ClimateDevice):
             lambda x: x.attributes.get('preset_mode', None) not in self._excluded, states
         ))
 
-        _LOGGER.error(f"Excluded by config: {self._excluded}")
-        _LOGGER.error(f"Resulting filtered states: {filtered_states}")
+        _LOGGER.debug(f"Excluded by config: {self._excluded}")
+        _LOGGER.debug(f"Resulting filtered states: {filtered_states}")
         
         self._target_temp = _reduce_attribute(filtered_states, 'temperature')
         self._current_temp = _reduce_attribute(filtered_states, 'current_temperature')
 
-        _LOGGER.error(f"Target temp: {self._target_temp}; Current temp: {self._current_temp}")
+        _LOGGER.debug(f"Target temp: {self._target_temp}; Current temp: {self._current_temp}")
 
         self._min_temp = _reduce_attribute(all_states, 'min_temp', reduce=max)
         self._max_temp = _reduce_attribute(all_states, 'max_temp', reduce=min)

--- a/custom_components/climate_group/climate.py
+++ b/custom_components/climate_group/climate.py
@@ -228,19 +228,22 @@ class ClimateGroup(ClimateDevice):
         elif off_actions:
             self._action = CURRENT_HVAC_OFF
 
-        all_presets = [state.attributes.get('preset_mode', None) for state in states]
-        if all_presets:
-            # Report the most common preset_mode.
-            self._preset = Counter(itertools.chain(all_presets)).most_common(1)[0][0]
-
         # if nothing is in excluded everything will be in 'filtered states'
         filtered_states = list(filter(
             lambda x: x.attributes.get('preset_mode', None) not in self._excluded, states
         ))
+        if not filtered_states:  # everything is being filtered, so show everything
+            filtered_states = states
 
         _LOGGER.debug(f"Excluded by config: {self._excluded}")
         _LOGGER.debug(f"Resulting filtered states: {filtered_states}")
-        
+
+        # get the most common state of non-filtered devices
+        all_presets = [state.attributes.get('preset_mode', None) for state in filtered_states]
+        if all_presets:
+            # Report the most common preset_mode.
+            self._preset = Counter(itertools.chain(all_presets)).most_common(1)[0][0]
+
         self._target_temp = _reduce_attribute(filtered_states, 'temperature')
         self._current_temp = _reduce_attribute(filtered_states, 'current_temperature')
 

--- a/custom_components/climate_group/manifest.json
+++ b/custom_components/climate_group/manifest.json
@@ -3,7 +3,7 @@
   "name": "Climate Group",
   "documentation": "https://github.com/daenny/climate_group",
   "dependencies": [],
-  "codeowners": ["@daenny"],
+  "codeowners": ["@daenny", "@b4dpxl"],
   "requirements": [],
   "homeassistant": "0.96.0"
 }

--- a/custom_components/climate_group/manifest.json
+++ b/custom_components/climate_group/manifest.json
@@ -3,7 +3,7 @@
   "name": "Climate Group",
   "documentation": "https://github.com/daenny/climate_group",
   "dependencies": [],
-  "codeowners": ["@daenny", "@b4dpxl"],
+  "codeowners": ["@daenny"],
   "requirements": [],
   "homeassistant": "0.96.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "domains": ["climate"],
+  "name": "Climate Group",
+  "render_readme": true,
+  "homeassistant": "0.96.0"
+}


### PR DESCRIPTION
With the `generic_thermostat`, the action was always being returned as `heat`, even when idle. There was no support for `away` preset mode either.